### PR TITLE
Fix group-wise evaluation

### DIFF
--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -32,7 +32,7 @@ seg.nii.gz	pred.nii.gz	2.0	0.743	0.923   False	False
 The script is compatible with both binary and multi-class segmentation tasks (e.g., nnunet region-based).
 The metrics are computed for each unique label (class) in the reference (ground truth) image.
 
-Authors: Jan Valosek
+Authors: Jan Valosek, Naga Karthik
 """
 
 
@@ -41,6 +41,8 @@ import argparse
 import numpy as np
 import nibabel as nib
 import pandas as pd
+from multiprocessing import Pool, cpu_count
+from functools import partial
 
 from MetricsReloaded.metrics.pairwise_measures import BinaryPairwiseMeasures as BPM
 
@@ -81,6 +83,8 @@ def get_parser():
                              'see: https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/metrics.html.')
     parser.add_argument('-output', type=str, default='metrics.csv', required=False,
                         help='Path to the output CSV file to save the metrics. Default: metrics.csv')
+    parser.add_argument('-jobs', type=int, default=cpu_count()//8, required=False,
+                        help='Number of CPU cores to use in parallel. Default: 1')
 
     return parser
 
@@ -171,8 +175,6 @@ def compute_metrics_single_subject(prediction, reference, metrics):
         # add the metrics to the output dictionary
         metrics_dict[label] = dict_seg
 
-        if label == max(unique_labels):
-            break       # break to loop to avoid processing the background label ("else" block)
     # Special case when both the reference and prediction images are empty
     else:
         label = 1
@@ -216,8 +218,14 @@ def build_output_dataframe(output_list):
     return df
 
 
-def main():
+def process_subject(prediction_file, reference_file, metrics):
+    """
+    Wrapper function to process a single subject.
+    """
+    return compute_metrics_single_subject(prediction_file, reference_file, metrics)
 
+
+def main():
     # parse command line arguments
     parser = get_parser()
     args = parser.parse_args()
@@ -228,18 +236,22 @@ def main():
     # Print the metrics to be computed
     print(f'Computing metrics: {args.metrics}')
 
+    print(f'Using {args.jobs} CPU cores in parallel ...')
+
     # Args.prediction and args.reference are paths to folders with multiple nii.gz files (i.e., MULTIPLE subjects)
     if os.path.isdir(args.prediction) and os.path.isdir(args.reference):
         # Get all files in the directories
         prediction_files, reference_files = get_images_in_folder(args.prediction, args.reference)
-        # Loop over the subjects
-        for i in range(len(prediction_files)):
-            # Compute metrics for each subject
-            metrics_dict = compute_metrics_single_subject(prediction_files[i], reference_files[i], args.metrics)
-            # Append the output dictionary (representing a single reference-prediction pair per subject) to the
-            # output_list
-            output_list.append(metrics_dict)
-    # Args.prediction and args.reference are paths nii.gz files from a SINGLE subject
+
+        # Use multiprocessing to parallelize the computation
+        with Pool(args.jobs) as pool:
+            # Create a partial function to pass the metrics argument to the process_subject function
+            func = partial(process_subject, metrics=args.metrics)
+            # Compute metrics for each subject in parallel
+            results = pool.starmap(func, zip(prediction_files, reference_files))
+
+            # Collect the results
+            output_list.extend(results)
     else:
         metrics_dict = compute_metrics_single_subject(args.prediction, args.reference, args.metrics)
         # Append the output dictionary (representing a single reference-prediction pair per subject) to the output_list


### PR DESCRIPTION
currently, the wrapper script `compute_metrics_reloaded.py` averages the results over all cases (i.e. when prediction and GT are empty, prediction empty GT not empty, etc. etc.). 

When pred and GT are both empty, the DSC is set to 1 automatically (which is correct as the model has rightly learned to not output a false positive). BUT, a lot of these outputs, skews the DSC in such a way that we don't how the model performs in case where there is lesion (i.e. does it predict the whole lesion, does it predict only partially, etc.)

SO, for this, we want to separate the evalutation of results into two cases: (1) when GT is _not_ Empty (and then average the resutls), (2) when the GT is empty, maybe compute the False Postive Rate. 

credit to Julian McGinnis who started this discussion! 