### PR TITLE
count as TP only when there's at least 10% overlap

### DIFF
--- a/MetricsReloaded/metrics/pairwise_measures.py
+++ b/MetricsReloaded/metrics/pairwise_measures.py
@@ -247,6 +247,7 @@ class BinaryPairwiseMeasures(object):
         pixdim=None,
         empty=False,
         dict_args={},
+        overlap_ratio=0.1,
     ):
 
         self.measures_dict = {
@@ -300,6 +301,7 @@ class BinaryPairwiseMeasures(object):
         self.connectivity = connectivity_type
         self.pixdim = pixdim
         self.dict_args = dict_args
+        self.overlap_ratio = overlap_ratio
 
     def __fp_map(self):
         """
@@ -1178,7 +1180,9 @@ class BinaryPairwiseMeasures(object):
     def lesion_wise_tp_fp_fn(self, truth, prediction):
         """
         Computes the true positives, false positives, and false negatives two masks. Masks are considered true positives
-        if at least one voxel overlaps between the truth and the prediction.
+        if there is at least `self.overlap_ratio` overlap between the truth and the prediction.
+        i.e. if self.overlap_ratio = 0.1, then at least 10% of the lesion voxels should overlap between the truth and 
+        the prediction to be considered as true positive.
         Adapted from: https://github.com/npnl/atlas2_grand_challenge/blob/main/isles/scoring.py#L341
 
         Parameters
@@ -1215,7 +1219,7 @@ class BinaryPairwiseMeasures(object):
             num_truth_lesion_voxels = np.sum(lesion)  # Total number of voxels in the GT lesion
             overlapping_voxels = np.sum(lesion * prediction)  # Number of GT voxels that overlap with the prediction
             # Check if at least 10% of the lesion voxels overlap with the prediction
-            if overlapping_voxels / num_truth_lesion_voxels >= 0.1:
+            if overlapping_voxels / num_truth_lesion_voxels >= self.overlap_ratio:
                 tp += 1
             else:
                 fn += 1
@@ -1226,7 +1230,7 @@ class BinaryPairwiseMeasures(object):
             lesion = labeled_prediction == idx_lesion
             # num_pred_lesion_voxels = np.sum(lesion)
             # overlapping_voxels = np.sum(lesion & truth)
-            # if overlapping_voxels / num_pred_lesion_voxels < 0.1:
+            # if overlapping_voxels / num_pred_lesion_voxels < self.overlap_ratio:
             #     fp += 1
             lesion_pred_sum = lesion + truth
             if(np.max(lesion_pred_sum) <= 1):  # No overlap

--- a/MetricsReloaded/metrics/pairwise_measures.py
+++ b/MetricsReloaded/metrics/pairwise_measures.py
@@ -1295,7 +1295,7 @@ class BinaryPairwiseMeasures(object):
         # if both are not empty, it's true positive
         else:
             tp, fp, _ = self.lesion_wise_tp_fp_fn(self.ref, self.pred)
-            # ppv = 1.0
+            ppv = 1.0
 
             # Compute ppv
             denom = tp + fp

--- a/MetricsReloaded/metrics/pairwise_measures.py
+++ b/MetricsReloaded/metrics/pairwise_measures.py
@@ -1257,6 +1257,9 @@ class BinaryPairwiseMeasures(object):
         elif not self.flag_empty_ref and self.flag_empty_pred:
             # Reference is not empty, prediction is empty --> model did not learn correctly (it's false negative)
             return 0.0
+        elif self.flag_empty_ref and not self.flag_empty_pred:
+            # Reference is empty, prediction is not empty --> model did not learn correctly (it's false positive)
+            return 0.0
         # if the predction is not empty and ref is empty, it's false positive
         # if both are not empty, it's true positive
         else:
@@ -1284,6 +1287,9 @@ class BinaryPairwiseMeasures(object):
             return 1.0
         elif not self.flag_empty_ref and self.flag_empty_pred:
             # Reference is not empty, prediction is empty --> model did not learn correctly (it's false negative)
+            return 0.0
+        elif self.flag_empty_ref and not self.flag_empty_pred:
+            # Reference is empty, prediction is not empty --> model did not learn correctly (it's false positive)
             return 0.0
         # if the predction is not empty and ref is empty, it's false positive
         # if both are not empty, it's true positive

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -20,7 +20,13 @@ similarity coefficient (DSC) and Normalized surface distance (NSD), use:
         -reference sub-001_T2w_seg.nii.gz
         -prediction sub-001_T2w_prediction.nii.gz
         -metrics dsc nsd
-
+For a lesion-wise evaluation with a minimum 10% overlap between GT and pred masks, use:
+    python compute_metrics_reloaded.py
+        -reference sub-001_T2w_seg.nii.gz
+        -prediction sub-001_T2w_prediction.nii.gz
+        -metrics dsc nsd rel_vol_error lesion_ppv lesion_sensitivity lesion_f1_score ref_count pred_count
+        --overlap-ratio 0.1
+        
 See https://arxiv.org/abs/2206.01653v5 for nice figures explaining the metrics!
 
 The output is saved to a CSV file, for example:


### PR DESCRIPTION
This PR updates the `lesion_f1_score` metric by modifying the condition for a "true positive" prediction. Previously, it was this [here](https://github.com/ivadomed/MetricsReloaded/blob/main/MetricsReloaded/metrics/pairwise_measures.py#L1231-L1236): 
```
Masks are considered true positives if at least one voxel overlaps between the truth and the prediction.
```

but taking only 1 voxel might be a bit too less so I updated the code to consider at least a 10% overlap to assign a prediction as "True Positive". Note that this is in line with how `anima` also assigns true positives. 

<details>
<summary> output of animaSegPerfAnalyzer -h </summary>

```
   -z <double>,  --MaxFalsePositiveRatioModerator <double>
     Percentage of the regions overlapping the tested lesion is not too
     much outside of this lesion. (default 0.65)

   -y <double>,  --MaxFalsePositiveRatio <double>
     Maximum of false positive ratio to limit the detection of a lesion in
     GT if a lesion in the image is too big. (default 0.7)

   -x <double>,  --MinOverlapRatio <double>
     Minimum overlap ratio to say if a lesion of the GT is detected.
     (default 0.10)

   -v <double>,  --MinLesionVolume <double>
     Min volume of lesion for "Lesions detection metrics" in mm^3 (default
     3mm^3).
```

</details>

I did not touch the False Positive part yet. 

Any thoughts, @valosekj @plbenveniste ? 