### PR TITLE
Allow json mapping usage

### DIFF
--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -83,6 +83,10 @@ def get_parser():
                              'see: https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/metrics.html.')
     parser.add_argument('-output', type=str, default='metrics.csv', required=False,
                         help='Path to the output CSV file to save the metrics. Default: metrics.csv')
+    parser.add_argument('-pred-map', type=str, metavar='<json>', default=None, required=False,
+                        help='JSON file containing the prediction mapping between the imaged structure and the corresponding integer value in the image ~/<your_path>/<myjson>.json')
+    parser.add_argument('-ref-map', type=str, metavar='<json>', default=None, required=False,
+                        help='JSON file containing the reference mapping between the imaged structure and the corresponding integer value in the image ~/<your_path>/<myjson>.json')
     parser.add_argument('-jobs', type=int, default=cpu_count()//8, required=False,
                         help='Number of CPU cores to use in parallel. Default: cpu_count()//8.')
 

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -241,6 +241,20 @@ def main():
     # Check if both -pred-map and -ref-map are referenced if at least one is specified
     if any((args.ref_map is None, args.pred_map is None)) and any((args.ref_map is not None, args.pred_map is not None)):
         raise ValueError(f'If used, both -ref-map and -pred-map must be provided.')
+    
+    # Load JSON mapping if provided
+    if any((args.ref_map is None, args.pred_map is None)):
+        # Load JSON files and create a dictionary
+        with open(args.ref_map, "r") as file:
+            ref_map = json.load(file)
+        # Load JSON files and create a dictionary
+        with open(args.pred_map, "r") as file:
+            pred_map = json.load(file)
+    else:
+        # Assign None value if not used
+        ref_map = None
+        pred_map = None
+
     # Print the metrics to be computed
     print(f'Computing metrics: {args.metrics}')
     print(f'Using {args.jobs} CPU cores in parallel ...')

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -255,6 +255,12 @@ def main():
     # Convert JSON data to pandas DataFrame
     df = build_output_dataframe(output_list)
 
+    # create a separate dataframe for columns where EmptyRef and EmptyPred is True
+    df_empty_masks = df[(df['EmptyRef'] == True) & (df['EmptyPred'] == True)]
+
+    # keep only the rows where either pred or ref is non-empty or both are non-empty
+    df = df[(df['EmptyRef'] == False) | (df['EmptyPred'] == False)]
+
     # Compute mean and standard deviation of metrics across all subjects
     df_mean = (df.drop(columns=['reference', 'prediction', 'EmptyRef', 'EmptyPred']).groupby('label').
                agg(['mean', 'std']).reset_index())

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -157,6 +157,11 @@ def compute_metrics_single_subject(prediction, reference, metrics):
     # append entry into the output_list to store the metrics for the current subject
     metrics_dict = {'reference': reference, 'prediction': prediction}
 
+    # NOTE: this is hacky fix to try to speed up metrics computation, tread very carefully
+    if len(unique_labels) == 2:
+        # compute metrics only for lesions
+        unique_labels = unique_labels[1:]
+
     # loop over all unique labels, e.g., voxels with values 1, 2, ...
     # by doing this, we can compute metrics for each label separately, e.g., separately for spinal cord and lesions
     for label in unique_labels:
@@ -172,17 +177,17 @@ def compute_metrics_single_subject(prediction, reference, metrics):
         # add the metrics to the output dictionary
         metrics_dict[label] = dict_seg
 
-    # Special case when both the reference and prediction images are empty
-    else:
-        label = 1
-        bpm = BPM(prediction_data, reference_data, measures=metrics)
-        dict_seg = bpm.to_dict_meas()
+    # # Special case when both the reference and prediction images are empty
+    # else:
+    #     label = 1
+    #     bpm = BPM(prediction_data, reference_data, measures=metrics)
+    #     dict_seg = bpm.to_dict_meas()
 
-        # Store info whether the reference or prediction is empty
-        dict_seg['EmptyRef'] = bpm.flag_empty_ref
-        dict_seg['EmptyPred'] = bpm.flag_empty_pred
-        # add the metrics to the output dictionary
-        metrics_dict[label] = dict_seg
+    #     # Store info whether the reference or prediction is empty
+    #     dict_seg['EmptyRef'] = bpm.flag_empty_ref
+    #     dict_seg['EmptyPred'] = bpm.flag_empty_pred
+    #     # add the metrics to the output dictionary
+    #     metrics_dict[label] = dict_seg
 
     return metrics_dict
 

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -238,6 +238,9 @@ def main():
     # Initialize a list to store the output dictionaries (representing a single reference-prediction pair per subject)
     output_list = list()
 
+    # Check if both -pred-map and -ref-map are referenced if at least one is specified
+    if any((args.ref_map is None, args.pred_map is None)) and any((args.ref_map is not None, args.pred_map is not None)):
+        raise ValueError(f'If used, both -ref-map and -pred-map must be provided.')
     # Print the metrics to be computed
     print(f'Computing metrics: {args.metrics}')
     print(f'Using {args.jobs} CPU cores in parallel ...')

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -43,6 +43,7 @@ import nibabel as nib
 import pandas as pd
 from multiprocessing import Pool, cpu_count
 from functools import partial
+import json
 
 from MetricsReloaded.metrics.pairwise_measures import BinaryPairwiseMeasures as BPM
 
@@ -130,7 +131,7 @@ def get_images_in_folder(prediction, reference):
     return prediction_files, reference_files
 
 
-def compute_metrics_single_subject(prediction, reference, metrics):
+def compute_metrics_single_subject(prediction, reference, metrics, ref_map, pred_map):
     """
     Compute MetricsReloaded metrics for a single subject
     :param prediction: path to the nifti image with the prediction
@@ -218,11 +219,11 @@ def build_output_dataframe(output_list):
     return df
 
 
-def process_subject(prediction_file, reference_file, metrics):
+def process_subject(prediction_file, reference_file, metrics, ref_map, pred_map):
     """
     Wrapper function to process a single subject.
     """
-    return compute_metrics_single_subject(prediction_file, reference_file, metrics)
+    return compute_metrics_single_subject(prediction_file, reference_file, metrics, ref_map, pred_map)
 
 
 def main():
@@ -262,14 +263,19 @@ def main():
         # Use multiprocessing to parallelize the computation
         with Pool(args.jobs) as pool:
             # Create a partial function to pass the metrics argument to the process_subject function
-            func = partial(process_subject, metrics=args.metrics)
+            func = partial(
+                process_subject, 
+                metrics=args.metrics, 
+                ref_map=ref_map, 
+                pred_map=pred_map
+            )
             # Compute metrics for each subject in parallel
             results = pool.starmap(func, zip(prediction_files, reference_files))
 
             # Collect the results
             output_list.extend(results)
     else:
-        metrics_dict = compute_metrics_single_subject(args.prediction, args.reference, args.metrics)
+        metrics_dict = compute_metrics_single_subject(args.prediction, args.reference, args.metrics, args.ref_map, args.pred_map)
         # Append the output dictionary (representing a single reference-prediction pair per subject) to the output_list
         output_list.append(metrics_dict)
 

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -247,7 +247,7 @@ def main():
         raise ValueError(f'If used, both -ref-map and -pred-map must be provided.')
     
     # Load JSON mapping if provided
-    if any((args.ref_map is None, args.pred_map is None)):
+    if not any((args.ref_map is None, args.pred_map is None)):
         # Load JSON files and create a dictionary
         with open(args.ref_map, "r") as file:
             ref_map = json.load(file)

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -161,7 +161,7 @@ def compute_metrics_single_subject(prediction, reference, metrics, ref_map, pred
         unique_labels = np.unique(np.concatenate((unique_labels_reference, unique_labels_prediction)))
     else:
         # Get the unique labels that are present in the reference OR prediction images
-        unique_labels = np.unique(np.concatenate(list(ref_map.keys()), list(pred_map.keys())))
+        unique_labels = np.unique(np.concatenate((list(ref_map.keys()), list(pred_map.keys()))))
 
     # append entry into the output_list to store the metrics for the current subject
     metrics_dict = {'reference': reference, 'prediction': prediction}

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -236,6 +236,20 @@ def main():
     # Check if both -pred-map and -ref-map are referenced if at least one is specified
     if any((args.ref_map is None, args.pred_map is None)) and any((args.ref_map is not None, args.pred_map is not None)):
         raise ValueError(f'If used, both -ref-map and -pred-map must be provided.')
+    
+    # Load JSON mapping if provided
+    if any((args.ref_map is None, args.pred_map is None)):
+        # Load JSON files and create a dictionary
+        with open(args.ref_map, "r") as file:
+            ref_map = json.load(file)
+        # Load JSON files and create a dictionary
+        with open(args.pred_map, "r") as file:
+            pred_map = json.load(file)
+    else:
+        # Assign None value if not used
+        ref_map = None
+        pred_map = None
+
     # Print the metrics to be computed
     print(f'Computing metrics: {args.metrics}')
     print(f'Using {args.jobs} CPU cores in parallel ...')

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -143,21 +143,25 @@ def compute_metrics_single_subject(prediction, reference, metrics, ref_map, pred
     prediction_data = load_nifti_image(prediction)
     reference_data = load_nifti_image(reference)
 
-    # check whether the images have the same shape and orientation
-    if prediction_data.shape != reference_data.shape:
-        raise ValueError(f'The prediction and reference (ground truth) images must have the same shape. '
-                         f'The prediction image has shape {prediction_data.shape} and the ground truth image has '
-                         f'shape {reference_data.shape}.')
+    if ref_map is None and pred_map is None:
+        # check whether the images have the same shape and orientation
+        if prediction_data.shape != reference_data.shape:
+            raise ValueError(f'The prediction and reference (ground truth) images must have the same shape. '
+                            f'The prediction image has shape {prediction_data.shape} and the ground truth image has '
+                            f'shape {reference_data.shape}.')
 
-    # get all unique labels (classes)
-    # for example, for nnunet region-based segmentation, spinal cord has label 1, and lesions have label 2
-    unique_labels_reference = np.unique(reference_data)
-    unique_labels_reference = unique_labels_reference[unique_labels_reference != 0]  # remove background
-    unique_labels_prediction = np.unique(prediction_data)
-    unique_labels_prediction = unique_labels_prediction[unique_labels_prediction != 0]  # remove background
+        # get all unique labels (classes)
+        # for example, for nnunet region-based segmentation, spinal cord has label 1, and lesions have label 2
+        unique_labels_reference = np.unique(reference_data)
+        unique_labels_reference = unique_labels_reference[unique_labels_reference != 0]  # remove background
+        unique_labels_prediction = np.unique(prediction_data)
+        unique_labels_prediction = unique_labels_prediction[unique_labels_prediction != 0]  # remove background
 
-    # Get the unique labels that are present in the reference OR prediction images
-    unique_labels = np.unique(np.concatenate((unique_labels_reference, unique_labels_prediction)))
+        # Get the unique labels that are present in the reference OR prediction images
+        unique_labels = np.unique(np.concatenate((unique_labels_reference, unique_labels_prediction)))
+    else:
+        # Get the unique labels that are present in the reference OR prediction images
+        unique_labels = np.unique(np.concatenate(list(ref_map.keys()), list(pred_map.keys())))
 
     # append entry into the output_list to store the metrics for the current subject
     metrics_dict = {'reference': reference, 'prediction': prediction}
@@ -166,8 +170,12 @@ def compute_metrics_single_subject(prediction, reference, metrics, ref_map, pred
     # by doing this, we can compute metrics for each label separately, e.g., separately for spinal cord and lesions
     for label in unique_labels:
         # create binary masks for the current label
-        prediction_data_label = np.array(prediction_data == label, dtype=float)
-        reference_data_label = np.array(reference_data == label, dtype=float)
+        if not isinstance(label, str):
+            prediction_data_label = np.array(prediction_data == label, dtype=float)
+            reference_data_label = np.array(reference_data == label, dtype=float)
+        else:
+            prediction_data_label = np.array(prediction_data == pred_map[label], dtype=float)
+            reference_data_label = np.array(reference_data == ref_map[label], dtype=float)
 
         bpm = BPM(prediction_data_label, reference_data_label, measures=metrics)
         dict_seg = bpm.to_dict_meas()

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -233,6 +233,9 @@ def main():
     # Initialize a list to store the output dictionaries (representing a single reference-prediction pair per subject)
     output_list = list()
 
+    # Check if both -pred-map and -ref-map are referenced if at least one is specified
+    if any((args.ref_map is None, args.pred_map is None)) and any((args.ref_map is not None, args.pred_map is not None)):
+        raise ValueError(f'If used, both -ref-map and -pred-map must be provided.')
     # Print the metrics to be computed
     print(f'Computing metrics: {args.metrics}')
     print(f'Using {args.jobs} CPU cores in parallel ...')

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -131,7 +131,7 @@ def get_images_in_folder(prediction, reference):
     return prediction_files, reference_files
 
 
-def compute_metrics_single_subject(prediction, reference, metrics, ref_map, pred_map):
+def compute_metrics_single_subject(prediction, reference, metrics, ref_map=None, pred_map=None):
     """
     Compute MetricsReloaded metrics for a single subject
     :param prediction: path to the nifti image with the prediction
@@ -227,7 +227,7 @@ def build_output_dataframe(output_list):
     return df
 
 
-def process_subject(prediction_file, reference_file, metrics, ref_map, pred_map):
+def process_subject(prediction_file, reference_file, metrics, ref_map=None, pred_map=None):
     """
     Wrapper function to process a single subject.
     """
@@ -283,7 +283,7 @@ def main():
             # Collect the results
             output_list.extend(results)
     else:
-        metrics_dict = compute_metrics_single_subject(args.prediction, args.reference, args.metrics, args.ref_map, args.pred_map)
+        metrics_dict = compute_metrics_single_subject(args.prediction, args.reference, args.metrics, ref_map, pred_map)
         # Append the output dictionary (representing a single reference-prediction pair per subject) to the output_list
         output_list.append(metrics_dict)
 

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -131,7 +131,7 @@ def get_images_in_folder(prediction, reference):
     return prediction_files, reference_files
 
 
-def compute_metrics_single_subject(prediction, reference, metrics, ref_map, pred_map):
+def compute_metrics_single_subject(prediction, reference, metrics, ref_map=None, pred_map=None):
     """
     Compute MetricsReloaded metrics for a single subject
     :param prediction: path to the nifti image with the prediction
@@ -232,7 +232,7 @@ def build_output_dataframe(output_list):
     return df
 
 
-def process_subject(prediction_file, reference_file, metrics, ref_map, pred_map):
+def process_subject(prediction_file, reference_file, metrics, ref_map=None, pred_map=None):
     """
     Wrapper function to process a single subject.
     """
@@ -288,7 +288,7 @@ def main():
             # Collect the results
             output_list.extend(results)
     else:
-        metrics_dict = compute_metrics_single_subject(args.prediction, args.reference, args.metrics, args.ref_map, args.pred_map)
+        metrics_dict = compute_metrics_single_subject(args.prediction, args.reference, args.metrics, ref_map, pred_map)
         # Append the output dictionary (representing a single reference-prediction pair per subject) to the output_list
         output_list.append(metrics_dict)
 

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -252,7 +252,7 @@ def main():
         raise ValueError(f'If used, both -ref-map and -pred-map must be provided.')
     
     # Load JSON mapping if provided
-    if any((args.ref_map is None, args.pred_map is None)):
+    if not any((args.ref_map is None, args.pred_map is None)):
         # Load JSON files and create a dictionary
         with open(args.ref_map, "r") as file:
             ref_map = json.load(file)

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -161,7 +161,7 @@ def compute_metrics_single_subject(prediction, reference, metrics, ref_map=None,
         unique_labels = np.unique(np.concatenate((unique_labels_reference, unique_labels_prediction)))
     else:
         # Get the unique labels that are present in the reference OR prediction images
-        unique_labels = np.unique(np.concatenate((list(ref_map.keys()), list(pred_map.keys()))))
+        unique_labels = list(ref_map.keys())
 
     # append entry into the output_list to store the metrics for the current subject
     metrics_dict = {'reference': reference, 'prediction': prediction}
@@ -236,8 +236,11 @@ def process_subject(prediction_file, reference_file, metrics, ref_map=None, pred
     """
     Wrapper function to process a single subject.
     """
-    return compute_metrics_single_subject(prediction_file, reference_file, metrics, ref_map, pred_map)
-
+    try:
+        return compute_metrics_single_subject(prediction_file, reference_file, metrics, ref_map, pred_map)
+    except Exception as e:
+        print(f"Error processing {prediction_file} and {reference_file}: {e}")
+        return {}
 
 def main():
     # parse command line arguments

--- a/compute_metrics_reloaded.py
+++ b/compute_metrics_reloaded.py
@@ -105,7 +105,7 @@ def load_nifti_image(file_path):
     if not os.path.exists(file_path):
         raise FileNotFoundError(f'File {file_path} does not exist.')
     nifti_image = nib.load(file_path)
-    return nifti_image.get_fdata()
+    return np.asanyarray(nifti_image.dataobj)
 
 
 def get_images_in_folder(prediction, reference):
@@ -176,11 +176,11 @@ def compute_metrics_single_subject(prediction, reference, metrics, ref_map=None,
     for label in unique_labels:
         # create binary masks for the current label
         if not isinstance(label, str):
-            prediction_data_label = np.array(prediction_data == label, dtype=float)
-            reference_data_label = np.array(reference_data == label, dtype=float)
+            prediction_data_label = (prediction_data == label).astype(np.uint8)
+            reference_data_label = (reference_data == label).astype(np.uint8)
         else:
-            prediction_data_label = np.array(prediction_data == pred_map[label], dtype=float)
-            reference_data_label = np.array(reference_data == ref_map[label], dtype=float)
+            prediction_data_label = (prediction_data == pred_map[label]).astype(np.uint8)
+            reference_data_label = (reference_data == ref_map[label]).astype(np.uint8)
 
         bpm = BPM(prediction_data_label, reference_data_label, measures=metrics)
         dict_seg = bpm.to_dict_meas()


### PR DESCRIPTION
## Description

In this PR, 2 new parser variables were integrated `-ref-map` and `-pred-map`. They both point to JSON sidecars that can be used to remap values present inside the corresponding reference and prediction images.

This is especially useful when values between the prediction and the ground truth are not the same and also to simply remove some structures from the comparison.

JSON example:
```json
{
        "T12":32,
        "T12-L1":91,
        "L1":41,
        "L1-L2":92,
        "L2":42,
        "L2-L3":93,
        "L3":43,
        "L3-L4":94,
        "L4":44,
        "L4-L5":95,
        "L5":45,
        "L5-S":100
}
```

Note: It can also be used to compute validation on a single structure present in the image whereas multiple other structures may appear:

For example:
```json
{
        "lesion":2
}
``` 

This way we could get rid of these lines:
https://github.com/ivadomed/MetricsReloaded/blob/2bad1f2115687871ac8c194fb5d222ba65de1d69/compute_metrics_reloaded.py#L160-L163

## Final table

<img width="772" alt="Screenshot 2024-11-28 at 11 11 32" src="https://github.com/user-attachments/assets/acab7883-0151-455b-88f1-59ac230d4210">
